### PR TITLE
Make a backup of trello FOR scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,19 +126,22 @@ Options
 
 ::
 
-    usage: trello-full-backup [-b] [-h] [-d [DEST]] [-B] [-L] [-C] [-o] [-a ATTACHMENT_SIZE]
+    usage: backup.py [-h] [-d [DEST]] [-i] [-t] [-B] [-L] [-C] [-o]
 
     Trello Full Backup
 
     optional arguments:
-      -b, --backup          Backup mode: Change names for tokens and only upload new attachments
       -h, --help            show this help message and exit
       -d [DEST]             Destination folder
+      -i, --incremental     incremental mode: Change names for tokens and only
+                            upload new attachments
+      -t, --tokenize        Tokenize the names for folders and files. Useful for
+                            scripts.
       -B, --closed-boards   Backup closed board
       -L, --archived-lists  Backup archived lists
       -C, --archived-cards  Backup archived cards
       -o, --organizations   Backup organizations
-      -a ATTACHMENT_SIZE, --attachment-size ATTACHMENT_SIZE
+      -a [ATTACHMENT_SIZE], --attachment-size [ATTACHMENT_SIZE]
                             Attachment size limit in bytes. Set to -1 to disable
                             the limit
 

--- a/README.rst
+++ b/README.rst
@@ -133,10 +133,9 @@ Options
     optional arguments:
       -h, --help            show this help message and exit
       -d [DEST]             Destination folder
-      -i, --incremental     incremental mode: Change names for tokens and only
-                            upload new attachments
+      -i, --incremental     Backup in an already existing folder incrementally
       -t, --tokenize        Tokenize the names for folders and files. Useful for
-                            scripts.
+                            scripts
       -B, --closed-boards   Backup closed board
       -L, --archived-lists  Backup archived lists
       -C, --archived-cards  Backup archived cards

--- a/README.rst
+++ b/README.rst
@@ -126,11 +126,12 @@ Options
 
 ::
 
-    usage: trello-full-backup [-h] [-d [DEST]] [-B] [-L] [-C] [-o] [-a ATTACHMENT_SIZE]
+    usage: trello-full-backup [-b] [-h] [-d [DEST]] [-B] [-L] [-C] [-o] [-a ATTACHMENT_SIZE]
 
     Trello Full Backup
 
     optional arguments:
+      -b, --backup          Backup mode: Change names for tokens and only upload new attachments
       -h, --help            show this help message and exit
       -d [DEST]             Destination folder
       -B, --closed-boards   Backup closed board
@@ -140,3 +141,9 @@ Options
       -a ATTACHMENT_SIZE, --attachment-size ATTACHMENT_SIZE
                             Attachment size limit in bytes. Set to -1 to disable
                             the limit
+
+Backup mode
+-----------
+The backup mode is useful for scripts. It will replace the names of the folders in each board by unique tokens.
+Furthermore, it allows the user to specify the same directory for backup.
+This will update all the json and description.md files. However it will download the attachment only if they have changed from the last backup.

--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -31,13 +31,13 @@ def get_extension(filename):
     ''' Get the extension of a file '''
     return os.path.splitext(filename)[1]
 
-def get_name(tokenize, real_name, backup_name, id):
+def get_name(tokenize, real_name, backup_name, element_id):
     ''' Get back the name for the tokenize mode or the real name in the card.
         If there is an ID, keep it
     '''
     if tokenize:
-        return '{}_{}'.format(id, backup_name)
-    return '{}_{}'.format(id, sanitize_file_name(real_name))
+        return '{}_{}'.format(element_id, backup_name)
+    return '{}_{}'.format(element_id, sanitize_file_name(real_name))
 
 def sanitize_file_name(name):
     ''' Stip problematic characters for a file name '''

--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -194,7 +194,7 @@ def cli():
                         action='store_const',
                         default=False,
                         const=True,
-                        help='incremental mode: Change names for tokens and only upload new attachments')
+                        help='Backup in an already existing folder incrementally')
 
     # Tokenize the names for folders and files
     parser.add_argument('-t', '--tokenize',
@@ -202,7 +202,7 @@ def cli():
                         action='store_const',
                         default=False,
                         const=True,
-                        help='Tokenize the names for folders and files. Useful for scripts.')
+                        help='Tokenize the names for folders and files. Useful for scripts')
 
     # Backup the boards that are closed
     parser.add_argument('-B', '--closed-boards',


### PR DESCRIPTION
This version will change folder names by tokens (id, shortlinks, etc..) and it allows to merge with a previous backup folder in an incremental way.

It does not download again already present attachments.

eg:

trello-full-backup -b -d path/to/dir/for/the/incremental/backup
---backup---

another time:
trello-full-backup -b -d path/to/dir/for/the/incremental/backup

This will update the json and md files in each folder and download only new attachments


My usage:
I like to make a daily backup of my Trello and push it on a private repository/Dropbox. I don't want to download all the files again every time.