### PR TITLE
fix authentication problems when downloading card attachments

### DIFF
--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -90,7 +90,8 @@ def download_attachments(c, max_size, tokenize=False):
             try:
                 content = requests.get(attachment['url'],
                                        stream=True,
-                                       timeout=ATTACHMENT_REQUEST_TIMEOUT)
+                                       timeout=ATTACHMENT_REQUEST_TIMEOUT,
+                                       headers={"Authorization":"OAuth oauth_consumer_key=\"{}\", oauth_token=\"{}\"".format(API_KEY, API_TOKEN)})
             except Exception:
                 sys.stderr.write('Failed download: {}'.format(attachment_name))
                 continue


### PR DESCRIPTION
I was facing the problem below when downloading the card attachments using the trello-full-backup python script provided by this repo:

> unauthorized permission requested

After debugging the application a little bit and reading the documentation of Trello REST API I found a solution, you will find more details about it here:

> **Authorization header**
>
> The Trello API will also accept authorization via an Authorization header with the format: `OAuth oauth_consumer_key="{{apiKey}}", oauth_token="{{apiToken}}"`.
>
> For instance, here is the same request as above, but using an Authorization header:
>
> `curl -H "Authorization: OAuth oauth_consumer_key=\"{{apiKey}}\", oauth_token=\"{{apiToken}}\"" https://api.trello.com/1/members/me`
>
> https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#authorization-header

When the attachment URL is under the trello endpoint it requires the caller to be authenticated in order to process the request and so download the file.

Note that, this process is probably not needed when the attachment URL points out to an S3 bucket or some other storage layer, it seems to be randomly assigned or maybe the Trello service now acts as a proxy in front of all requests to improve a little bit the security as before those files were all acessible publicly by default? I don't know, but with this change we get card attachments being downloaded successfully again. =)