### PR TITLE
Handle http errors more gracefully

### DIFF
--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -132,7 +132,7 @@ def backup_board(board, args):
 
     tokenize = bool(args.tokenize)
 
-    board_details = requests.get(''.join((
+    board_request = requests.get(''.join((
         '{}boards/{}{}&'.format(API, board["id"], auth),
         'actions=all&actions_limit=1000&',
         'cards={}&'.format(FILTERS[args.archived_cards]),
@@ -143,7 +143,9 @@ def backup_board(board, args):
         'member_fields=all&',
         'checklists=all&',
         'fields=all'
-    ))).json()
+    )))
+    board_request.raise_for_status()
+    board_details = board_request.json()
 
     board_dir = sanitize_file_name(board_details['name'])
 
@@ -299,16 +301,22 @@ def cli():
 
     if args.my_boards:
         my_boards_url = '{}members/me/boards{}'.format(API, auth)
-        org_boards_data['me'] = requests.get(my_boards_url).json()
+        my_boards_request = requests.get(my_boards_url)
+        my_boards_request.raise_for_status()
+        org_boards_data['me'] = my_boards_request.json()
 
     orgs = []
     if args.orgs:
         org_url = '{}members/me/organizations{}'.format(API, auth)
-        orgs = requests.get(org_url).json()
+        org_request = requests.get(org_url)
+        org_request.raise_for_status()
+        orgs = org_request.json()
 
     for org in orgs:
         boards_url = '{}organizations/{}/boards{}'.format(API, org['id'], auth)
-        org_boards_data[org['name']] = requests.get(boards_url).json()
+        boards_request = requests.get(boards_url)
+        boards_request.raise_for_status()
+        org_boards_data[org['name']] = boards_request.json()
 
     for org, boards in org_boards_data.items():
         mkdir(org)


### PR DESCRIPTION
The HTTP request to the API sometimes gives an error response, with an HTML body. You're currently calling .json() on the Response object, which gives a JSONDecodeError, and hides the HTTP error which is the real cause.

This pull request asks the requests module to explicitly raise a requests.exceptions.HTTPError instead.

Also, if an error occurs when backing up one board, it carries on with the rest of the boards, and reports all the errors at the end.