### PR TITLE
Missing card backups

### DIFF
--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -170,7 +170,7 @@ def backup_board(board, args):
 
         # Enter list directory
         os.chdir(list_name)
-        cards = lists[ls['id']] if ls['id'] in lists else []
+        cards = lists[ls['id']]
 
         for id_card, c in enumerate(cards):
             backup_card(id_card, c, args.attachment_size, tokenize)

--- a/trello_full_backup/backup.py
+++ b/trello_full_backup/backup.py
@@ -1,5 +1,5 @@
 import sys
-import itertools
+import collections
 import os
 import argparse
 import re
@@ -157,10 +157,11 @@ def backup_board(board, args):
           board_details['name'], 'with id', board['id'], 'to', file_name)
     write_file(file_name, board_details)
 
-    lists = {}
-    cs = itertools.groupby(board_details['cards'], key=lambda x: x['idList'])
-    for list_id, cards in cs:
-        lists[list_id] = sorted(list(cards), key=lambda card: card['pos'])
+    lists = collections.defaultdict(list)
+    for card in board_details['cards']:
+        lists[card['idList']].append(card)
+    for list_cards in lists.values():
+        list_cards.sort(key=lambda card: card['pos'])
 
     for id_list, ls in enumerate(board_details['lists']):
         list_name = get_name(tokenize, ls['name'], ls["id"], id_list)


### PR DESCRIPTION
There are many cards which are present in the board's $NAME_full.json backup, but don't get their own card.json file, and their attachments aren't downloaded.

The problem is here:
```
    cs = itertools.groupby(board_details['cards'], key=lambda x: x['idList'])
    for list_id, cards in cs:
        lists[list_id] = sorted(list(cards), key=lambda card: card['pos'])
```

This assumes that all the cards for any list are together in one batch in the board's data. If they are split up (which I've seen happen), the last batch in the `itertools.groupby` overwrites any previous ones in `list`, and only those cards are backed up.

This pull request fixes that.